### PR TITLE
Implemented query depth limit

### DIFF
--- a/example/social/server/server.go
+++ b/example/social/server/server.go
@@ -12,7 +12,11 @@ import (
 var schema *graphql.Schema
 
 func init() {
-	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.MaxParallelism(20)}
+	opts := []graphql.SchemaOpt{
+		graphql.UseFieldResolvers(),
+		graphql.MaxParallelism(20),
+		graphql.MaxDepth(10),
+	}
 	schema = graphql.MustParseSchema(social.Schema, &social.Resolver{}, opts...)
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -99,6 +99,14 @@ func UseFieldResolvers() SchemaOpt {
 	}
 }
 
+// Specifies the maximum depth allowed in the query selection. The default is set to 5.
+// This prevents infinite selection of recursive fields
+func MaxDepth(n int) SchemaOpt {
+	return func(s *Schema) {
+		s.schema.MaxDepth = n
+	}
+}
+
 // Response represents a typical response of a GraphQL server. It may be encoded to JSON directly or
 // it may be further processed to a custom response type, for example to include custom error data.
 type Response struct {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -66,6 +66,7 @@ type FragmentDecl struct {
 
 type Selection interface {
 	isSelection()
+	GetSelections() []Selection
 }
 
 type Field struct {
@@ -89,9 +90,22 @@ type FragmentSpread struct {
 	Loc        errors.Location
 }
 
-func (Field) isSelection()          {}
+func (Field) isSelection() {}
+func (f Field) GetSelections() []Selection {
+	return f.Selections
+}
 func (InlineFragment) isSelection() {}
+func (inf InlineFragment) GetSelections() []Selection {
+	return inf.Selections
+}
 func (FragmentSpread) isSelection() {}
+func (FragmentSpread) GetSelections() []Selection {
+	return []Selection{}
+}
+func (Fragment) isSelection() {}
+func (f Fragment) GetSelections() []Selection {
+	return f.Selections
+}
 
 func Parse(queryString string) (*Document, *errors.QueryError) {
 	l := common.NewLexer(queryString)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -47,6 +47,7 @@ type Schema struct {
 	enums           []*Enum
 
 	UseFieldResolvers bool
+	MaxDepth int
 }
 
 // Resolve a named type in the schema by its name.
@@ -237,6 +238,7 @@ func New() *Schema {
 		entryPointNames: make(map[string]string),
 		Types:           make(map[string]NamedType),
 		Directives:      make(map[string]*DirectiveDecl),
+		MaxDepth:        5,
 	}
 	for n, t := range Meta.Types {
 		s.Types[n] = t


### PR DESCRIPTION
Fixes #118 - this basically adds a validation check for query depth limit. It is a basic prevention measure against unwanted deep queries. 

### Does this break existing API?

No. However, by default maximum query depth limit is set to 5.

### How can I change/set maximum depth limit?

When invoking `graphql.ParseSchema()` or `graphql.MustParseSchema()` to parse the schema, you pass in `graphql.MaxDepth(n)` as an argument. For an example, take a look at `./example/social/server/server.go`

### Additional Notes

1. Unit tests are missing
1. To test functionally, run `./example/social/social.go` and send it a query which is 11+ levels deep. You can change the `social.go` code to test less deep query. 