### PR TITLE
Handle parsing of `time.Time` type struct fields

### DIFF
--- a/example/social/social.go
+++ b/example/social/social.go
@@ -3,6 +3,7 @@ package social
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 const Schema = `
@@ -21,6 +22,8 @@ const Schema = `
 		role: Role!
 	}
 
+	scalar Time	
+
 	type User implements Admin {
 		id: ID!
 		name: String!
@@ -29,6 +32,7 @@ const Schema = `
 		phone: String!
 		address: [String!]
 		friends(page: Pagination): [User]
+		createdAt: Time!
 	}
 
 	input Pagination {
@@ -54,13 +58,14 @@ type admin interface {
 }
 
 type user struct {
-	Id      string
-	Name    string
-	Role    string
-	Email   string
-	Phone   string
-	Address *[]string
-	Friends *[]*user
+	Id        string
+	Name      string
+	Role      string
+	Email     string
+	Phone     string
+	Address   *[]string
+	Friends   *[]*user
+	CreatedAt time.Time
 }
 
 func (u user) IdResolver() string {
@@ -100,36 +105,40 @@ func (u user) FriendsResolver(args struct{ Page *page }) (*[]*user, error) {
 
 var users = []*user{
 	{
-		Id:      "0x01",
-		Name:    "Albus Dumbledore",
-		Role:    "ADMIN",
-		Email:   "Albus@hogwarts.com",
-		Phone:   "000-000-0000",
-		Address: &[]string{"Office @ Hogwarts", "where Horcruxes are"},
+		Id:        "0x01",
+		Name:      "Albus Dumbledore",
+		Role:      "ADMIN",
+		Email:     "Albus@hogwarts.com",
+		Phone:     "000-000-0000",
+		Address:   &[]string{"Office @ Hogwarts", "where Horcruxes are"},
+		CreatedAt: time.Now(),
 	},
 	{
-		Id:      "0x02",
-		Name:    "Harry Potter",
-		Role:    "USER",
-		Email:   "harry@hogwarts.com",
-		Phone:   "000-000-0001",
-		Address: &[]string{"123 dorm room @ Hogwarts", "456 random place"},
+		Id:        "0x02",
+		Name:      "Harry Potter",
+		Role:      "USER",
+		Email:     "harry@hogwarts.com",
+		Phone:     "000-000-0001",
+		Address:   &[]string{"123 dorm room @ Hogwarts", "456 random place"},
+		CreatedAt: time.Now(),
 	},
 	{
-		Id:      "0x03",
-		Name:    "Hermione Granger",
-		Role:    "USER",
-		Email:   "hermione@hogwarts.com",
-		Phone:   "000-000-0011",
-		Address: &[]string{"233 dorm room @ Hogwarts", "786 @ random place"},
+		Id:        "0x03",
+		Name:      "Hermione Granger",
+		Role:      "USER",
+		Email:     "hermione@hogwarts.com",
+		Phone:     "000-000-0011",
+		Address:   &[]string{"233 dorm room @ Hogwarts", "786 @ random place"},
+		CreatedAt: time.Now(),
 	},
 	{
-		Id:      "0x04",
-		Name:    "Ronald Weasley",
-		Role:    "USER",
-		Email:   "ronald@hogwarts.com",
-		Phone:   "000-000-0111",
-		Address: &[]string{"411 dorm room @ Hogwarts", "981 @ random place"},
+		Id:        "0x04",
+		Name:      "Ronald Weasley",
+		Role:      "USER",
+		Email:     "ronald@hogwarts.com",
+		Phone:     "000-000-0111",
+		Address:   &[]string{"411 dorm room @ Hogwarts", "981 @ random place"},
+		CreatedAt: time.Now(),
 	},
 }
 

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/exec/packer"
@@ -192,6 +193,8 @@ func makeScalarExec(t *schema.Scalar, resolverType reflect.Type) (Resolvable, er
 		implementsType = t.Name == "String" || t.Name == "ID"
 	case *bool:
 		implementsType = t.Name == "Boolean"
+	case *time.Time:
+		implementsType = t.Name == "Time"
 	case packer.Unmarshaler:
 		implementsType = r.ImplementsGraphQLType(t.Name)
 	}


### PR DESCRIPTION
Currently when you declare a struct for the schema type, the datetime field must be of type `graphql.Time` in order for schema to be parsed and validated. This PR enables the datetime fields to be of type `time.Time`. This change can work really well when using field resolvers. 

`social.go` example was also updated to show relevant changes

### Additional Notes

This PR does not break any existing API or client code. Unit tests were not updated.

### Test Notes 

1. Run `./example/social/social.go`
1. Then send it a query with `createdAt` field in the selection. 
1. Verify the timestamp output