### PR TITLE
Expose selected fields in resolver context

### DIFF
--- a/selected/selected.go
+++ b/selected/selected.go
@@ -1,0 +1,26 @@
+package selected
+
+import (
+	"context"
+	"errors"
+)
+
+const ContextKey = "Resolver_Selected_Fields"
+
+type SelectedFields func() []SelectedField
+
+type SelectedField struct {
+	Name     string
+	Args     map[string]interface{}
+	Selected []SelectedField
+}
+
+func GetFieldsFromContext(ctx context.Context) (fields []SelectedField, err error) {
+	fieldsFunc, ok := ctx.Value(ContextKey).(SelectedFields)
+	if ok == false {
+		err = errors.New("could not get graphql fields from context")
+		return
+	}
+	fields = fieldsFunc()
+	return
+}


### PR DESCRIPTION
This fixes #17. Basically, it exposes the selected field tree in the context for the resolvers and downstream usage. 

There are two PRs open in upstream that fix this issue but I think the solution in this PR is better and we can merge it in our branch to make use of it quickly. The PRs in upstream have been open for a while.

### Does this break the existing api?

No

### What if I do not want the selection tree? Does it have performance impact?

There should be very negligible performance impact. The selection tree is lazily added; meaning, it is added to the context only when you request it. The lazy evaluation happens via a closure function. 

### How can I use it?

In your resolver, you can do `selected.GetFieldsFromContext(ctx)` which returns `[]selected.SelectedField, error`. For an example, take a look at `example/social/social.go` 

### Test Notes
- Run `./example/social/server/server.go`
- Visit `http://localhost:9011/` and run this query. Verify that some basic stuff about selection tree is logged in the console

```
query GetUser($userId: ID!, $page: Pagination) {
  user(id: $userId) {
    id
    name
    email
    phone
    friends(page: $page) {
      id
      name
    	email
    	phone
    }
  }
}

variables:

{
  "userId": "0x02",
  "page": {
    "first": 1,
    "last": 0
  }
}
```

### TODO
- add unit tests