### PR TITLE
DT4-201 Exploring Customized Directives

### DIFF
--- a/example/social/social.go
+++ b/example/social/social.go
@@ -16,9 +16,9 @@ const Schema = `
 	}
 	
 	type Query {
-		admin(id: ID!, role: Role = ADMIN): Admin!
+		admin(id: ID!, role: Role = ADMIN): Admin! @is_authenticated
 		user(id: ID!): User!
-        search(text: String!): [SearchResult]!
+		search(text: String!): [SearchResult]!
 	}
 	
 	interface Admin {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -176,13 +176,6 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 
 		if f.field.MethodIndex != -1 {
 			var in []reflect.Value
-			if f.field.DirectiveFunc != nil {
-				err := f.field.DirectiveFunc()
-				if err != nil {
-					return errors.Errorf("%s", err)
-				}
-				return nil
-			}
 
 			if f.field.HasContext {
 				// lazily evaluate
@@ -209,6 +202,10 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 				res = res.Elem()
 			}
 			result = res.Field(f.field.FieldIndex)
+			if result.Kind() == reflect.String && f.field.DirectiveFunc != nil {
+				str := f.field.DirectiveFunc(result.String())
+				result.SetString(str)
+			}
 		}
 
 		return nil

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -202,9 +202,10 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 				res = res.Elem()
 			}
 			result = res.Field(f.field.FieldIndex)
+
 			if result.Kind() == reflect.String && f.field.DirectiveFunc != nil {
 				str := f.field.DirectiveFunc(result.String())
-				result.SetString(str)
+				result = reflect.ValueOf(&str).Elem()
 			}
 		}
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -203,8 +203,15 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 			}
 			result = res.Field(f.field.FieldIndex)
 
-			if result.Kind() == reflect.String && f.field.DirectiveFunc != nil {
-				str := f.field.DirectiveFunc(result.String())
+			if result.Kind() == reflect.String && len(f.field.StringDirectiveFuncs) != 0 {
+				var str string
+				for i, directiveFunc := range f.field.StringDirectiveFuncs {
+					if i == 0 {
+						str = directiveFunc(result.String())
+					} else {
+						str = directiveFunc(str)
+					}
+				}
 				result = reflect.ValueOf(&str).Elem()
 			}
 		}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -176,6 +176,14 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 
 		if f.field.MethodIndex != -1 {
 			var in []reflect.Value
+			if f.field.DirectiveFunc != nil {
+				err := f.field.DirectiveFunc()
+				if err != nil {
+					return errors.Errorf("%s", err)
+				}
+				return nil
+			}
+
 			if f.field.HasContext {
 				// lazily evaluate
 				resCtx := context.WithValue(traceCtx, pubselected.ContextKey, selectedFields(f.sels))

--- a/internal/exec/selected/directive.go
+++ b/internal/exec/selected/directive.go
@@ -1,0 +1,54 @@
+package selected
+
+import (
+	"reflect"
+
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/graph-gophers/graphql-go/internal/exec/packer"
+)
+
+type DirectiveFunc func() error
+
+func skipByDirective(r *Request, directives common.DirectiveList) bool {
+	if d := directives.Get("skip"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf(false)}
+		v, err := p.Pack(d.Args.MustGet("if").Value(r.Vars))
+		if err != nil {
+			r.AddError(errors.Errorf("%s", err))
+		}
+		if err == nil && v.Bool() {
+			return true
+		}
+	}
+
+	if d := directives.Get("include"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf(false)}
+		v, err := p.Pack(d.Args.MustGet("if").Value(r.Vars))
+		if err != nil {
+			r.AddError(errors.Errorf("%s", err))
+		}
+		if err == nil && !v.Bool() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func makeDirective(r *Request, directives common.DirectiveList) DirectiveFunc {
+	if d := directives.Get("date"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf("")}
+		v, err := p.Pack(d.Args.MustGet("as").Value(r.Vars))
+		if err != nil {
+			r.AddError(errors.Errorf("%s", err))
+		}
+		if err == nil && v.String() == "" {
+			return nil
+		}
+		return func() error {
+			return nil
+		}
+	}
+	return nil
+}

--- a/internal/exec/selected/directive.go
+++ b/internal/exec/selected/directive.go
@@ -2,13 +2,14 @@ package selected
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 )
 
-type DirectiveFunc func() error
+type DirectiveFunc func(string) string
 
 func skipByDirective(r *Request, directives common.DirectiveList) bool {
 	if d := directives.Get("skip"); d != nil {
@@ -37,18 +38,38 @@ func skipByDirective(r *Request, directives common.DirectiveList) bool {
 }
 
 func makeDirective(r *Request, directives common.DirectiveList) DirectiveFunc {
-	if d := directives.Get("date"); d != nil {
-		p := packer.ValuePacker{ValueType: reflect.TypeOf("")}
-		v, err := p.Pack(d.Args.MustGet("as").Value(r.Vars))
+	if d := directives.Get("to_upper"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf(false)}
+		v, err := p.Pack(d.Args.MustGet("if").Value(r.Vars))
 		if err != nil {
 			r.AddError(errors.Errorf("%s", err))
 		}
-		if err == nil && v.String() == "" {
-			return nil
-		}
-		return func() error {
-			return nil
+		if err == nil && v.Bool() {
+			return strings.ToUpper
 		}
 	}
+
+	if d := directives.Get("to_lower"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf(false)}
+		v, err := p.Pack(d.Args.MustGet("if").Value(r.Vars))
+		if err != nil {
+			r.AddError(errors.Errorf("%s", err))
+		}
+		if err == nil && v.Bool() {
+			return strings.ToLower
+		}
+	}
+
+	if d := directives.Get("to_title"); d != nil {
+		p := packer.ValuePacker{ValueType: reflect.TypeOf(false)}
+		v, err := p.Pack(d.Args.MustGet("if").Value(r.Vars))
+		if err != nil {
+			r.AddError(errors.Errorf("%s", err))
+		}
+		if err == nil && v.Bool() {
+			return strings.Title
+		}
+	}
+
 	return nil
 }

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -2,6 +2,7 @@ package selected
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
 	"sync"
 
@@ -31,6 +32,10 @@ func ApplyOperation(r *Request, s *resolvable.Schema, op *query.Operation) []Sel
 	var obj *resolvable.Object
 	switch op.Type {
 	case query.Query:
+		if authDirective(r, op.Directives) == false {
+			r.AddError(errors.Errorf("%s", http.StatusText(http.StatusUnauthorized)))
+			return nil
+		}
 		obj = s.Query.(*resolvable.Object)
 	case query.Mutation:
 		obj = s.Mutation.(*resolvable.Object)

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -44,13 +44,13 @@ type Selection interface {
 
 type SchemaField struct {
 	resolvable.Field
-	Alias         string
-	Args          map[string]interface{}
-	PackedArgs    reflect.Value
-	Sels          []Selection
-	Async         bool
-	FixedResult   reflect.Value
-	DirectiveFunc DirectiveFunc
+	Alias                string
+	Args                 map[string]interface{}
+	PackedArgs           reflect.Value
+	Sels                 []Selection
+	Async                bool
+	FixedResult          reflect.Value
+	StringDirectiveFuncs []StringDirectiveFunc
 }
 
 type TypeAssertion struct {
@@ -132,15 +132,15 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 				}
 
 				fieldSels := applyField(r, fe.ValueExec, field.Selections)
-				directiveFunc := makeDirective(r, field.Directives)
+				stringDirectives := extractStringDirectives(r, field.Directives)
 				flattenedSels = append(flattenedSels, &SchemaField{
-					Field:         *fe,
-					Alias:         field.Alias.Name,
-					Args:          args,
-					PackedArgs:    packedArgs,
-					Sels:          fieldSels,
-					Async:         fe.HasContext || fe.ArgsPacker != nil || fe.HasError || HasAsyncSel(fieldSels),
-					DirectiveFunc: directiveFunc,
+					Field:                *fe,
+					Alias:                field.Alias.Name,
+					Args:                 args,
+					PackedArgs:           packedArgs,
+					Sels:                 fieldSels,
+					Async:                fe.HasContext || fe.ArgsPacker != nil || fe.HasError || HasAsyncSel(fieldSels),
+					StringDirectiveFuncs: stringDirectives,
 				})
 			}
 

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -46,6 +46,11 @@ var metaSrc = `
 		reason: String = "No longer supported"
 	) on FIELD_DEFINITION | ENUM_VALUE
 
+	# Directs the executor to format this field according to the ` + "`" + `as` + "`" + ` argument specified layout.
+	directive @date(
+		as: String!
+	) on FIELD
+
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 	#
 	# In some cases, you need to provide options to alter GraphQL's execution behavior

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -46,9 +46,19 @@ var metaSrc = `
 		reason: String = "No longer supported"
 	) on FIELD_DEFINITION | ENUM_VALUE
 
-	# Directs the executor to format this field according to the ` + "`" + `as` + "`" + ` argument specified layout.
-	directive @date(
-		as: String!
+	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
+	directive @to_upper(
+		if: Boolean!
+	) on FIELD
+
+	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
+	directive @to_lower(
+		if: Boolean!
+	) on FIELD
+
+	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
+	directive @to_title(
+		if: Boolean!
 	) on FIELD
 
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -47,19 +47,23 @@ var metaSrc = `
 	) on FIELD_DEFINITION | ENUM_VALUE
 
 	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
-	directive @to_upper(
+	directive @strings_upper(
 		if: Boolean!
 	) on FIELD
 
-	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
-	directive @to_lower(
+	# Directs the executor to format this field to lower case according to the ` + "`" + `if` + "`" + ` argument is true.
+	directive @strings_lower(
 		if: Boolean!
 	) on FIELD
 
-	# Directs the executor to format this field to upper case according to the ` + "`" + `if` + "`" + ` argument is true.
-	directive @to_title(
+	# Directs the executor to format this field to be titled according to the ` + "`" + `if` + "`" + ` argument is true.
+	directive @strings_title(
 		if: Boolean!
 	) on FIELD
+
+	# Auth directives.
+	directive @is_authenticated on QUERY | FIELD
+	directive @has_scope on QUERY | FIELD
 
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 	#

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -61,9 +61,8 @@ var metaSrc = `
 		if: Boolean!
 	) on FIELD
 
-	# Auth directives.
-	directive @is_authenticated on QUERY | FIELD
-	directive @has_scope on QUERY | FIELD
+	# TODO: Auth directives.
+	directive @is_authenticated on QUERY
 
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 	#


### PR DESCRIPTION
## Description
- (Took me time to dig a bit into those internal packages.)
- Basic implementations of string operstions' directives.
- Different from `skip` and `include` which are eagerly excecuted, string ops ones are lazily executed since they have to wait the return value coming back from actual query execution.
- Not sure if this is the most optimal way but feedbacks are appreciated.

## TODO
- Read more about schema parsing. Not sure if query level directives are parsed properly.

## Test Notes
- Use the example server.
- `cd $GOPATH/src/github.com/graph-gophers/graphql-go/example/social/server`
- `go run server.go`
- Browse to `http://localhost:9011/`
- Try queries with string operation directives like:
```graphql
query GetUser($userId: ID!) {
  user(id: $userId) {
    id
    name
    email @strings_upper(if: true)
    role @strings_lower(if: true)
    friends {
      name @strings_upper(if: true) @strings_lower(if: true) @strings_title(if: true)
      createdAt
    }
  }
}
```
```graphql
{
  "userId": "0x01"
}
```