### PR TITLE
DT4-116: Validate query before sending to resolver

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -176,6 +176,12 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		if err != nil {
 			return &Response{Errors: []*errors.QueryError{err}}
 		}
+
+		err = validateInput(t, v.Name.Name, variables, *s)
+		if err != nil {
+			return &Response{Errors: []*errors.QueryError{err}}
+		}
+
 		varTypes[v.Name.Name] = introspection.WrapType(t)
 	}
 	traceCtx, finish := s.tracer.TraceQuery(ctx, queryString, operationName, variables, varTypes)
@@ -207,4 +213,51 @@ func getOperation(document *query.Document, operationName string) (*query.Operat
 		return nil, fmt.Errorf("no operation with name %q", operationName)
 	}
 	return op, nil
+}
+
+func validateInput(objType common.Type, varName string, variables map[string]interface{}, sch Schema) *errors.QueryError {
+	var err *errors.QueryError
+	err = &errors.QueryError {
+		Message: "Missing required parameters",
+	}
+
+	value := variables[varName]
+
+	if value == nil {
+		found := false
+		for vars := range variables {
+			if varName == vars {
+				found = true
+				break
+			}
+		}
+
+		if found == false {
+			err.Message = fmt.Sprintf("%s%s%s", "Expected: '", varName, "'")
+			return err
+		}
+	}
+
+	if inputObj, ok := objType.(*schema.InputObject); ok {
+		if nestedVariables, ok := value.(map[string]interface{}); ok {
+			foundCount := 0
+			for _, inputVal := range inputObj.Values {
+				t, err := common.ResolveType(inputVal.Type, sch.schema.Resolve)
+				if err != nil {
+					return err
+				}
+
+				qErr := validateInput(t, inputVal.Name.Name, nestedVariables, sch)
+				if qErr == nil {
+					foundCount++
+				}
+			}
+
+			if foundCount != len(nestedVariables) {
+				return err
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description ###
Currently if you send a GraphQL Query missing some parameters, the system will forward it to the appropriate resolver and then throw an error. The ticket requested that we have our graphql-go library check if the submitted GraphQL query conforms to the defined schema.

### Notes ###
1. This solution grew from beyond the original requirements of ensuring that the required properties are submitted. I originally just ran a check to see if the non-null root elements exist, but then realised that the nested elements were not being validated. Recursion to the rescue.
2. You will note that the validationInput method does not exist within the validation.go common library. This is because the incoming variables are not accessible from that method, and to avoid having to pass it (and modify large swaths of code) I included it in the base graphql.go file.
3. There's a logic problem determining if we have a property that was spelt wrong, or if the property is missing. My current solution is to count the # of elements that were matched to the schema, but that does not allow the system to return a "nice" error.

### Test Cases ###

#### Prerequisites ####
1. Ensure that Omega-Core is using this branch for it's graphql-go library
2. Run Omega-Core

#### Test Case 1 ####
1. Submit a query (properly formatted)
Expected Result: Query should reach the appropriate resolver
Before Solution: Same thing. No difference

#### Test Case 2 ####
1. Misspell a property in your GraphQL Query
2. Submit the query
Expected Result: Server should return "Missing required parameters"
Before Solution: The query reaches the resolver, and a different error is returned

#### Test Case 3 ####
1. Do not include a required property in your GraphQL Query
2. Submit the query
Expected Result: Server should return "Expected: '[YOUR_MISSING_PROPERTY]'"
Before Solution: The query reaches the resolver, and a different error is returned